### PR TITLE
Fix issue with new `include_host`

### DIFF
--- a/custom_components/arpscan_tracker/device_tracker.py
+++ b/custom_components/arpscan_tracker/device_tracker.py
@@ -73,7 +73,7 @@ class ArpScanDeviceScanner(DeviceScanner):
 
     def get_device_name(self, mac):
         """Return the name of the given device."""
-        
+
         return mac.replace(':', '')
 
 
@@ -115,9 +115,10 @@ class ArpScanDeviceScanner(DeviceScanner):
             parts = line.split()
             ipv4 = parts[0]
 
-            if not ipv4 in include_hosts:
-                _LOGGER.debug("Excluded %s", ipv4)
-                continue
+            if include_hosts:
+                if not ipv4 in include_hosts:
+                    _LOGGER.debug("Excluded %s", ipv4)
+                    continue
 
             if ipv4 in exclude_hosts:
                 _LOGGER.debug("Excluded %s", ipv4)


### PR DESCRIPTION
Removed white space on empty line `def get_device_name` (line 76).

Added a check to see if `include_host` is empty before excluding devices not in the list.
This is to fix a bug (#5) where if there is no `include_host` flag, all devices are excluded.
I have tested this in my installation, and it appears to fix the issue - there may be a better way to do this check than nesting another if statement.